### PR TITLE
fix: typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Options:
   --print-only                Only print the command but not run
   --color=WHEN                Enable color output, options are 'always', 'never', or 'auto'
 
-Replacements in cammand:
+Replacements in command:
   {}                          Input argument
   {.}                         Input argument without extension
   {/}                         Basename of input line

--- a/src/main.vala
+++ b/src/main.vala
@@ -207,7 +207,7 @@ public class Varallel.CLI {
         // g_print will force to convert character set to windows's code page
         // which is imcompatible windows's bash, zsh, etc.
         opt_context.set_help_enabled (false);
-        opt_context.set_description ("Replacements in cammand:
+        opt_context.set_description ("Replacements in command:
   {}                          Input argument
   {.}                         Input argument without extension
   {/}                         Basename of input line


### PR DESCRIPTION
cammand->command